### PR TITLE
Fixes the following error on Ember 3.22:

### DIFF
--- a/addon/components/x-option.js
+++ b/addon/components/x-option.js
@@ -1,4 +1,4 @@
-import { scheduleOnce } from '@ember/runloop';
+import { scheduleOnce, schedule } from '@ember/runloop';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { isArray, A } from '@ember/array';
@@ -36,7 +36,7 @@ export default Component.extend({
    * @property selected
    * @type Boolean
    */
-  selected: computed('value', 'select.{value,multiple}', function() {
+  selected: computed('value', 'select.{value,multiple}', function () {
     if (this.get('select.multiple') && isArray(this.get('select.value'))) {
       let selectValue = A(this.get('select.value'));
 
@@ -80,8 +80,11 @@ export default Component.extend({
    *
    * @override
    */
-  willDestroyElement: function() {
-    this.get('unregister')(this);
+  willDestroyElement: function () {
+    schedule('actions', () => {
+      this.get('unregister')(this);
+    });
+
     this._super.apply(this, arguments);
-  }
+  },
 });


### PR DESCRIPTION
> Uncaught Error: Assertion Failed: You attempted to update [] on <Array:ember187>, but it had already been used previously in the same computation. Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.
    
Reference: https://github.com/adopted-ember-addons/emberx-select/issues/277
    
Recommended solution by @pzuraq: https://github.com/emberjs/ember.js/issues/18613#issuecomment-652588091